### PR TITLE
카테고리 메이페이시 연속 일수 계산 수정

### DIFF
--- a/book/views.py
+++ b/book/views.py
@@ -28,7 +28,7 @@ def get_status(goal):   # 시작, 성공, 연속 일수를 리턴하는 함수
     start_days = (datetime.date.today() - goal.created).days + 1
     success_days = goal.certifies.filter(achievement=True).count()
     continuity_days = 0
-    for i in range(1, certifies.count()):
+    for i in range(certifies.count()):
         date = datetime.date.today() - timedelta(days=i+1)  # 어제부터 거꾸로 가면서 성공했는지 확인
         certify = goal.certifies.filter(created=date)
         if not certify.first():     # 인증이 없다면 종료

--- a/book/views.py
+++ b/book/views.py
@@ -28,8 +28,8 @@ def get_status(goal):   # 시작, 성공, 연속 일수를 리턴하는 함수
     start_days = (datetime.date.today() - goal.created).days + 1
     success_days = goal.certifies.filter(achievement=True).count()
     continuity_days = 0
-    for i in range(certifies.count()):
-        date = datetime.date.today() - timedelta(days=i)  # 오늘부터 거꾸로 가면서 성공했는지 확인
+    for i in range(1, certifies.count()):
+        date = datetime.date.today() - timedelta(days=i+1)  # 어제부터 거꾸로 가면서 성공했는지 확인
         certify = goal.certifies.filter(created=date)
         if not certify.first():     # 인증이 없다면 종료
             break

--- a/free/views.py
+++ b/free/views.py
@@ -28,7 +28,7 @@ def get_status(goal):   # 시작, 성공, 연속 일수를 리턴하는 함수
     start_days = (datetime.date.today() - goal.created).days + 1
     success_days = goal.certifies.filter(achievement=True).count()
     continuity_days = 0
-    for i in range(1, certifies.count()):
+    for i in range(certifies.count()):
         date = datetime.date.today() - timedelta(days=i+1)  # 어제부터 거꾸로 가면서 성공했는지 확인
         certify = goal.certifies.filter(created=date)
         if not certify.first():     # 인증이 없다면 종료

--- a/free/views.py
+++ b/free/views.py
@@ -28,8 +28,8 @@ def get_status(goal):   # 시작, 성공, 연속 일수를 리턴하는 함수
     start_days = (datetime.date.today() - goal.created).days + 1
     success_days = goal.certifies.filter(achievement=True).count()
     continuity_days = 0
-    for i in range(certifies.count()):
-        date = datetime.date.today() - timedelta(days=i)  # 오늘부터 거꾸로 가면서 성공했는지 확인
+    for i in range(1, certifies.count()):
+        date = datetime.date.today() - timedelta(days=i+1)  # 어제부터 거꾸로 가면서 성공했는지 확인
         certify = goal.certifies.filter(created=date)
         if not certify.first():     # 인증이 없다면 종료
             break

--- a/health/views.py
+++ b/health/views.py
@@ -28,7 +28,7 @@ def get_status(goal):   # 시작, 성공, 연속 일수를 리턴하는 함수
     start_days = (datetime.date.today() - goal.created).days + 1
     success_days = goal.certifies.filter(achievement=True).count()
     continuity_days = 0
-    for i in range(1, certifies.count()):
+    for i in range(certifies.count()):
         date = datetime.date.today() - timedelta(days=i+1)  # 어제부터 거꾸로 가면서 성공했는지 확인
         certify = goal.certifies.filter(created=date)
         if not certify.first():     # 인증이 없다면 종료

--- a/health/views.py
+++ b/health/views.py
@@ -28,8 +28,8 @@ def get_status(goal):   # 시작, 성공, 연속 일수를 리턴하는 함수
     start_days = (datetime.date.today() - goal.created).days + 1
     success_days = goal.certifies.filter(achievement=True).count()
     continuity_days = 0
-    for i in range(certifies.count()):
-        date = datetime.date.today() - timedelta(days=i)  # 오늘부터 거꾸로 가면서 성공했는지 확인
+    for i in range(1, certifies.count()):
+        date = datetime.date.today() - timedelta(days=i+1)  # 어제부터 거꾸로 가면서 성공했는지 확인
         certify = goal.certifies.filter(created=date)
         if not certify.first():     # 인증이 없다면 종료
             break

--- a/study/views.py
+++ b/study/views.py
@@ -28,7 +28,7 @@ def get_status(goal):   # 시작, 성공, 연속 일수를 리턴하는 함수
     start_days = (datetime.date.today() - goal.created).days + 1
     success_days = goal.certifies.filter(achievement=True).count()
     continuity_days = 0
-    for i in range(1, certifies.count()):
+    for i in range(certifies.count()):
         date = datetime.date.today() - timedelta(days=i+1)  # 어제부터 거꾸로 가면서 성공했는지 확인
         certify = goal.certifies.filter(created=date)
         if not certify.first():     # 인증이 없다면 종료

--- a/study/views.py
+++ b/study/views.py
@@ -28,8 +28,8 @@ def get_status(goal):   # 시작, 성공, 연속 일수를 리턴하는 함수
     start_days = (datetime.date.today() - goal.created).days + 1
     success_days = goal.certifies.filter(achievement=True).count()
     continuity_days = 0
-    for i in range(certifies.count()):
-        date = datetime.date.today() - timedelta(days=i)  # 오늘부터 거꾸로 가면서 성공했는지 확인
+    for i in range(1, certifies.count()):
+        date = datetime.date.today() - timedelta(days=i+1)  # 어제부터 거꾸로 가면서 성공했는지 확인
         certify = goal.certifies.filter(created=date)
         if not certify.first():     # 인증이 없다면 종료
             break

--- a/wakeup/views.py
+++ b/wakeup/views.py
@@ -29,7 +29,7 @@ def get_status(goal):   # 시작, 성공, 연속 일수를 리턴하는 함수
     success_days = goal.certifies.filter(achievement=True).count()
     continuity_days = 0
     for i in range(certifies.count()):
-        date = datetime.date.today() - timedelta(days=i)  # 오늘부터 거꾸로 가면서 성공했는지 확인
+        date = datetime.date.today() - timedelta(days=i+1)  # 어제부터 거꾸로 가면서 성공했는지 확인
         certify = goal.certifies.filter(created=date)
         if not certify.first():     # 인증이 없다면 종료
             break


### PR DESCRIPTION
- 자정이 되고 다음날로 날짜가 바뀌었을 때, 아직 오늘 인증을 등록하지 않았으므로 연속 일수가 0으로 초기화되는 버그 발견
- 연속 일수를 계산할 때 어제부터 체크하도록 수정하여 해결